### PR TITLE
Adding popular DICOM-Extensions

### DIFF
--- a/lib/Migration/RegisterMimeType.php
+++ b/lib/Migration/RegisterMimeType.php
@@ -10,7 +10,7 @@ class RegisterMimeType implements IRepairStep {
 
     public function __construct() {
         // Define the custom mimetype mapping
-        $this->customMimetypeMapping = array("dcm" => array("application/dicom"));
+        $this->customMimetypeMapping = array("dcm" => array("application/dicom"),"ima" => array("application/dicom"),"dicom" => array("application/dicom"),"dic" => array("application/dicom"),"dc3" => array("application/dicom"));
     }
 
     public function getName() {


### PR DESCRIPTION
Registering other popular DICOM-Extensions for this wonderful Dicomviewer!
Opening of the viewer by clicking on the various files worked with all file extensions in Release 0.0.3.
In current release 1.0.2 the viewer window unfortunately only opens if extension is "dcm". Is there any way to enable it for the other extensions, too?