### PR TITLE
Add ownCloud version dependency and make it so JS/CSS only load on the files app

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,17 @@ For more information, see the blog post [Nextcloud in Digital Imaging](https://n
 
 ### Installation
 
-On your Nextcloud, simply navigate to Apps > Multimedia > DICOM Viewer, and enable it.
+Build the app using the instructions below and then on Nextcloud, simply navigate to Apps > Multimedia > DICOM Viewer, and enable it.
 
 
 ### Build
 
 Firstly, install NodeJS for JavaScript dependencies, then follow these steps:
-1. Run `make && make source` command to build source code
-2. Copy `build/artifacts/source/dicomviewer` into `path-to-nextcloud/apps`
-3. Enable the DICOM Viewer app
+1. Clone this repository
+2. Change into the directory you have cloned this repository into
+3. Run `make && make source` command to build source code
+4. Copy `build/artifacts/source/dicomviewer` into `path-to-nextcloud/apps`
+5. Enable the DICOM Viewer app
 
 
 ### Roadmap

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -4,14 +4,21 @@ namespace OCA\DICOMViewer\AppInfo;
 
 use OCP\Util;
 
-Util::addStyle('dicomviewer', 'viewer');
-Util::addStyle('dicomviewer', 'sidebar');
-Util::addStyle('dicomviewer', 'bootstrap_accordion');
-Util::addStyle('dicomviewer', 'viewerMain');
-Util::addStyle('dicomviewer', 'viewerMainDialog');
-Util::addStyle('dicomviewer', 'captureImageDialog');
-Util::addStyle('dicomviewer', 'external/font-awesome/font-awesome.min');
-Util::addScript('dicomviewer', 'app.bundle');
+// Only load CSS/JS on the Files app
+$eventDispatcher = \OC::$server->getEventDispatcher();
+$eventDispatcher->addListener(
+	'OCA\Files::loadAdditionalScripts',
+	function () {
+		Util::addStyle('dicomviewer', 'viewer');
+		Util::addStyle('dicomviewer', 'sidebar');
+		Util::addStyle('dicomviewer', 'bootstrap_accordion');
+		Util::addStyle('dicomviewer', 'viewerMain');
+		Util::addStyle('dicomviewer', 'viewerMainDialog');
+		Util::addStyle('dicomviewer', 'captureImageDialog');
+		Util::addStyle('dicomviewer', 'external/font-awesome/font-awesome.min');
+		Util::addScript('dicomviewer', 'app.bundle');
+	}
+);
 
 // Get the server name
 $server_name = '';
@@ -28,3 +35,4 @@ $csp->addAllowedImageDomain('*');
 $csp->addAllowedFontDomain("'self'");
 $csp->allowEvalScript(false);
 $cspManager->addDefaultPolicy($csp);
+

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,6 +16,7 @@ See [README](https://github.com/ayselafsar/dicomviewer) for a list of full featu
     <bugs>https://github.com/ayselafsar/dicomviewer/issues</bugs>
     <dependencies>
         <nextcloud min-version="12" max-version="14"/>
+        <owncloud min-version="10" max-version="10"/>
     </dependencies>
     <repository type="git">https://github.com/ayselafsar/dicomviewer.git</repository>
     <screenshot small-thumbnail="https://raw.githubusercontent.com/ayselafsar/dicomviewer/master/screenshots/viewer1-small.png">https://raw.githubusercontent.com/ayselafsar/dicomviewer/master/screenshots/viewer1.png</screenshot>


### PR DESCRIPTION
I've been using this app with ownCloud with some slight modifications. 

I have added the ownCloud version dependency to appinfo/info.xml and made it so the CSS/JS only loads when you are on the Files app (this was to avoid collisions with CSS libraries used in other apps). I also made the installation instructions a little clearer where I tripped up with them during my installation!

Everything here is compatible with NextCloud as well. I've tested this in ownCloud 10.0.3.