### PR TITLE
Drop support for NC12

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@ See [README](https://github.com/ayselafsar/dicomviewer) for a list of full featu
     <screenshot small-thumbnail="https://raw.githubusercontent.com/ayselafsar/dicomviewer/master/screenshots/dump1-small.png">https://raw.githubusercontent.com/ayselafsar/dicomviewer/master/screenshots/dump1.png</screenshot>
     <screenshot small-thumbnail="https://raw.githubusercontent.com/ayselafsar/dicomviewer/master/screenshots/dump2-small.png">https://raw.githubusercontent.com/ayselafsar/dicomviewer/master/screenshots/dump2.png</screenshot>
     <dependencies>
-        <nextcloud min-version="12" max-version="16"/>
+        <nextcloud min-version="13" max-version="16"/>
     </dependencies>
     <repair-steps>
         <install>


### PR DESCRIPTION
NC12 has reached his End Of Life. And because Nextcloud is following a strict release and support policy, NC 12 is also no longer supported by them.

Furthermore PHP 5.4 and 7.0 also has reached there EOL. Nextcloud is going to drop support for them with the upcoming NC16-Release.

Both NC12 and the outdated PHP-Versions have some major security-issues, so users are strongly encouraged to update there installations to NC 15. And the performance-update with the newer versions is amazing.

Considering all this, I strongly suggest, dicomviewer is dropping support for NC12 as well.

Replacement for closed PR #42 