### PR TITLE
Start the support of NC18, drop 13 and 14

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@ See [README](https://github.com/ayselafsar/dicomviewer) for a list of full featu
     <screenshot small-thumbnail="https://raw.githubusercontent.com/ayselafsar/dicomviewer/master/screenshots/dump1-small.png">https://raw.githubusercontent.com/ayselafsar/dicomviewer/master/screenshots/dump1.png</screenshot>
     <screenshot small-thumbnail="https://raw.githubusercontent.com/ayselafsar/dicomviewer/master/screenshots/dump2-small.png">https://raw.githubusercontent.com/ayselafsar/dicomviewer/master/screenshots/dump2.png</screenshot>
     <dependencies>
-        <nextcloud min-version="13" max-version="17"/>
+        <nextcloud min-version="15" max-version="18"/>
     </dependencies>
     <repair-steps>
         <install>


### PR DESCRIPTION
1. As the release of NC18 is due to come, its time to support it. Testing on Beta1 trough rc2 has shown no problems.
2. As of security-reasons supporting NC13 and NC14 should be dropped. Official support for those versions by nextcloud has already been stopped.