### PR TITLE
#133 Hide capture tool in viewer when download is hidden in public share link

### DIFF
--- a/lib/Controller/DisplayController.php
+++ b/lib/Controller/DisplayController.php
@@ -570,6 +570,9 @@ class DisplayController extends Controller {
             $downloadUrlPrefix = $this->getNextcloudBasePath().'/s/'.$shareToken.'/download';
             $dicomJson = $this->generateDICOMJson($dicomFilePaths, $dicomFileNodes, $selectedFileFullPath, $dicomParentFullPath, null, $downloadUrlPrefix, true, $singlePublicFileDownload);
 
+            // Hide capture tool in viewer when download is hidden in public share link
+            $dicomJson['hideCapture'] = $share->getHideDownload();
+
             $dicomJson = $this->convertToUTF8($dicomJson);
             $response = new JSONResponse($dicomJson);
             return $response;


### PR DESCRIPTION
This PR fixes #133 