### PR TITLE
Fix DICOM viewer for public shares

### DIFF
--- a/lib/Controller/DisplayController.php
+++ b/lib/Controller/DisplayController.php
@@ -17,6 +17,7 @@ use OCP\AppFramework\Http\StreamResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\Files\IMimeTypeDetector;
 use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
 use OCP\IConfig;
 use Psr\Log\LoggerInterface;
 use OCP\IRequest;
@@ -633,12 +634,22 @@ class DisplayController extends Controller {
 
             $shareNode = $share->getNode();
             if ($shareNode->getType() == 'dir') {
-                $selectedFileFullPath = $this->dataFolder.$shareNode->get($filepath)->getPath();
+                // Determine which folder to scan - if filepath is provided, use that subfolder
+                $folderToScan = $shareNode;
+                if (!empty($filepath)) {
+                    try {
+                        $folderToScan = $shareNode->get($filepath);
+                    } catch (NotFoundException $e) {
+                        $folderToScan = $shareNode;
+                    }
+                }
+
+                $selectedFileFullPath = $this->dataFolder.$folderToScan->getPath();
                 $dicomParentFullPath = $this->dataFolder.$shareNode->getPath();
 
-                // Get all DICOM files in the share folder and sub folders
+                // Get all DICOM files in the folder and sub folders
                 $parentPathToRemove = $shareNode->getPath();
-                list($dicomFilePaths, $dicomFileNodes) = $this->getAllDICOMFilesInFolder($parentPathToRemove, $shareNode, false);
+                list($dicomFilePaths, $dicomFileNodes) = $this->getAllDICOMFilesInFolder($parentPathToRemove, $folderToScan, true);
             } else {
                 $selectedFileFullPath = null;
                 $dicomParentFullPath = $this->dataFolder;
@@ -649,8 +660,9 @@ class DisplayController extends Controller {
                 array_push($dicomFileNodes, $shareNode);
             }
 
-            $downloadUrlPrefix = $this->getNextcloudBasePath().'/s/'.$shareToken.'/download';
-            $dicomJson = $this->generateDICOMJson($dicomFilePaths, $dicomFileNodes, $selectedFileFullPath, $dicomParentFullPath, null, $downloadUrlPrefix, true, $singlePublicFileDownload);
+            // Use WebDAV public endpoint for file downloads (public.php is a direct entry point, not routed via index.php)
+            $downloadUrlPrefix = $this->urlGenerator->getWebroot().'/public.php/dav/files/'.$shareToken;
+            $dicomJson = $this->generateDICOMJson($dicomFilePaths, $dicomFileNodes, $selectedFileFullPath, $dicomParentFullPath, null, $downloadUrlPrefix, false, $singlePublicFileDownload);
 
             // Hide capture tool in viewer when download is hidden in public share link
             $dicomJson['hideCapture'] = $share->getHideDownload();

--- a/src/utils/getPublicShareToken.js
+++ b/src/utils/getPublicShareToken.js
@@ -1,2 +1,12 @@
-const sharingTokenElmt = document.getElementById('sharingToken')
-export default () => sharingTokenElmt && sharingTokenElmt.value
+export default () => {
+    const sharingTokenElmt = document.getElementById('sharingToken')
+    const token = sharingTokenElmt && sharingTokenElmt.value
+
+    // Fallback: extract from URL if element not found
+    if (!token) {
+        const urlMatch = window.location.pathname.match(/\/s\/([^/]+)/)
+        return urlMatch ? urlMatch[1] : null
+    }
+
+    return token
+}

--- a/src/utils/isPublicPage.js
+++ b/src/utils/isPublicPage.js
@@ -1,2 +1,9 @@
-const isPublicElmt = document.getElementById('isPublic')
-export default () => !!(isPublicElmt && isPublicElmt.value === '1')
+export default () => {
+    const isPublicElmt = document.getElementById('isPublic')
+    const isPublic = !!(isPublicElmt && isPublicElmt.value === '1')
+
+    // Fallback: check if we're on a public share URL pattern
+    const isPublicUrl = /\/s\/[A-Za-z0-9]+/.test(window.location.pathname) || window.location.pathname.includes('/public.php')
+
+    return isPublic || isPublicUrl
+}

--- a/src/utils/registerFileActions.js
+++ b/src/utils/registerFileActions.js
@@ -2,13 +2,24 @@ import { registerFileAction, FileAction, FileType, Permission } from '@nextcloud
 import { translate as t } from '@nextcloud/l10n';
 import { generateUrl } from "@nextcloud/router";
 import AppIcon from './AppIcon.js';
+import isPublicPage from './isPublicPage.js';
+import getPublicShareToken from './getPublicShareToken.js';
 
 function openWithDICOMViewer(node) {
-    const dicomUrl = window.location.protocol + '//' + window.location.host + generateUrl(`/apps/dicomviewer/dicomjson?file=${node.owner}|${node.fileid}|1`);
+    const isPublic = isPublicPage();
+    let dicomUrl;
+
+    if (isPublic) {
+        const shareToken = getPublicShareToken();
+        dicomUrl = window.location.protocol + '//' + window.location.host + generateUrl(`/apps/dicomviewer/publicdicomjson?file=${shareToken}|${node.path}`);
+    } else {
+        dicomUrl = window.location.protocol + '//' + window.location.host + generateUrl(`/apps/dicomviewer/dicomjson?file=${node.owner}|${node.fileid}|1`);
+    }
 
     // Open viewer in a new tab
+    const viewerUrl = generateUrl(`/apps/dicomviewer/ncviewer/viewer/dicomjson?url=${dicomUrl}`);
     const tab = window.open('about:blank');
-    tab.location = generateUrl(`/apps/dicomviewer/ncviewer/viewer/dicomjson?url=${dicomUrl}`);
+    tab.location = viewerUrl;
     tab.focus();
 }
 


### PR DESCRIPTION
- Detect public pages and use appropriate endpoint (publicdicomjson vs dicomjson)
- Add URL fallback for public page/token detection when DOM elements unavailable
- Scan clicked subfolder instead of share root for DICOM files
- Enable scanning files without proper DICOM MIME type (isOpenNoExtension)
- Use WebDAV public endpoint instead of download redirect for file access

Fixes https://github.com/ayselafsar/dicomviewer/issues/108