### PR TITLE
Fix UTF-8 double encoding issue with accented characters

### DIFF
--- a/lib/Controller/DisplayController.php
+++ b/lib/Controller/DisplayController.php
@@ -139,7 +139,11 @@ class DisplayController extends Controller {
                 $d[$k] = $this->convertToUTF8($v);
             }
         } else if (is_string($d)) {
-            return utf8_encode($d);
+            // Only convert if not already UTF-8 to avoid double encoding
+            if (mb_detect_encoding($d, 'UTF-8', true) === false) {
+                return mb_convert_encoding($d, 'UTF-8', 'ISO-8859-1');
+            }
+            return $d;
         }
         return $d;
     }


### PR DESCRIPTION
Replace utf8_encode() with mb_convert_encoding() and check if string is already UTF-8 before converting to avoid double encoding that causes 404 errors on paths with accented characters (e.g., 'Santé').

Fixes https://github.com/ayselafsar/dicomviewer/issues/119