### PR TITLE
Fix: font 404 error/warn when WebGL is unavailable

### DIFF
--- a/lib/Controller/DisplayController.php
+++ b/lib/Controller/DisplayController.php
@@ -471,7 +471,7 @@ class DisplayController extends Controller {
 
         // Replace nextcloud base path with the actual path in this environment
         // TODO: Move this to replace __NEXTCLOUD_BASE_PATH__ on app install and htaccess update only
-	    if (str_ends_with($fullFilePath, '.html') || str_ends_with($fullFilePath, '.js')) {
+	    if (str_ends_with($fullFilePath, '.html') || str_ends_with($fullFilePath, '.js') || str_ends_with($fullFilePath, '.css')) {
 	    	$fpHandle = fopen('php://temp/maxmemory:'.$filename.'.customized', 'r+');
 	        fputs($fpHandle, str_replace('__NEXTCLOUD_BASE_PATH__', $this->getNextcloudBasePath(), file_get_contents($fullFilePath)));
 	        rewind($fpHandle);

--- a/src/public.js
+++ b/src/public.js
@@ -3,6 +3,7 @@ import isPublicPage from './utils/isPublicPage.js';
 import isDicom from './utils/isDicom.js'
 import getPublicShareToken from './utils/getPublicShareToken.js';
 import getPublicFileName from './utils/getPublicFileName.js';
+import ensureWebGL from './utils/ensureWebGL.js';
 
 window.addEventListener('DOMContentLoaded', function() {
     if (!isPublicPage() || !isDicom()) {
@@ -21,5 +22,12 @@ window.addEventListener('DOMContentLoaded', function() {
         div.style.marginTop = '10px';
         div.innerHTML = `<a href="${viewerUrl}" id="openDicomFile" class="button" target="_blank"><span class="icon icon-toggle"></span>${' ' + t('dicomviewer', 'View') + ' '}</a>`;
         previewElmt.appendChild(div);
+
+        // Don't open a viewer that can't render: warn if WebGL is blocked.
+        div.querySelector('#openDicomFile').addEventListener('click', (e) => {
+            if (!ensureWebGL()) {
+                e.preventDefault();
+            }
+        });
     }
 });

--- a/src/utils/ensureWebGL.js
+++ b/src/utils/ensureWebGL.js
@@ -1,0 +1,28 @@
+import { showError } from '@nextcloud/dialogs';
+import { translate as t } from '@nextcloud/l10n';
+
+/**
+ * Returns true if a WebGL context can be created. Otherwise shows a message
+ * and returns false. The viewer draws through WebGL.
+ *
+ * @return {boolean}
+ */
+export default function ensureWebGL() {
+    let supported = false;
+    try {
+        const canvas = document.createElement('canvas');
+        supported = !!(window.WebGLRenderingContext
+            && (canvas.getContext('webgl') || canvas.getContext('experimental-webgl')));
+    } catch (e) {
+        supported = false;
+    }
+
+    if (!supported) {
+        showError(
+            t('dicomviewer', 'DICOM Viewer requires WebGL, which is either disabled or blocked. Either allow WebGL for this site, or try using a different browser.'),
+            { timeout: 0 },
+        );
+    }
+
+    return supported;
+}

--- a/src/utils/registerFileActions.js
+++ b/src/utils/registerFileActions.js
@@ -4,8 +4,13 @@ import { generateUrl } from "@nextcloud/router";
 import AppIcon from './AppIcon.js';
 import isPublicPage from './isPublicPage.js';
 import getPublicShareToken from './getPublicShareToken.js';
+import ensureWebGL from './ensureWebGL.js';
 
 function openWithDICOMViewer(node) {
+    if (!ensureWebGL()) {
+        return;
+    }
+
     const isPublic = isPublicPage();
     let dicomUrl;
 

--- a/src/views/DICOMView.vue
+++ b/src/views/DICOMView.vue
@@ -6,11 +6,17 @@
 import { generateUrl } from '@nextcloud/router'
 import isPublicPage from '../utils/isPublicPage.js';
 import getPublicShareToken from '../utils/getPublicShareToken.js';
+import ensureWebGL from '../utils/ensureWebGL.js';
 
 export default {
     name: 'DICOMView',
 
     async mounted() {
+        if (!ensureWebGL()) {
+            this.$parent.close();
+            return;
+        }
+
         let dicomUrl;
 
         const file = this.fileList.find((file) => file.fileid === this.fileid);


### PR DESCRIPTION
## Summary

Two small UX fixes:

1.  **Font 404**  the bundled web font fails to load because the `__NEXTCLOUD_BASE_PATH__` placeholder is substituted only in `.html`/`.js`, not `.css`. The UI silently falls back to a system font.
2.  **Blank viewport on browsers without WebGL** dicomviewer/Cornerstone3D renders via WebGL. Privacy-hardened browsers (fingerprinting/tracking protection) disable WebGL, so the user gets a blank viewport and a cryptic console error with no explanation. With those changes, we now detect this up front and show a clear message.

* * *

## Changes

### 1\. Substitute `__NEXTCLOUD_BASE_PATH__` in `.css`
`getDICOMViewerFile()` rewrites the `__NEXTCLOUD_BASE_PATH__` placeholder to the real path, but only for `.html` and `.js`. `app.bundle.css` references the font through the same placeholder, so the URL is never rewritten and the request is facing a 404.

- **Error** (network)
  ```
  GET https://nextcloud.DOMAIN.TLD/apps/dicomviewer/ncviewer/__NEXTCLOUD_BASE_PATH__/apps/dicomviewer/ncviewer/31fb9346313fc3740d7b.woff2
  → HTTP/2 404
  ```

- **Error** (console)
  ```
  downloadable font: download failed (font-family: "Inter" style:normal weight:400 stretch:100 src index:0): status=2147746065
  source: https://nextcloud.DOMAIN.TLD/apps/dicomviewer/ncviewer/__NEXTCLOUD_BASE_PATH__/apps/dicomviewer/ncviewer/31fb9346313fc3740d7b.woff2
  ```

- **Fix** (`lib/Controller/DisplayController.php`):
  ```php
  if (str_ends_with($fullFilePath, '.html') || str_ends_with($fullFilePath, '.js') || str_ends_with($fullFilePath, '.css')) {
  ```

- **Toast shown to users**:
> This viewer needs WebGL to display images, but your browser is blocking it (often due to fingerprinting or tracking protection). Please allow WebGL for this site, or open the link in another browser.

## Testing

- **Font:** the *Inter* font now loads — no `__NEXTCLOUD_BASE_PATH__…woff2` 404/ system-font fallback  
    
    ```
    Request URL         https://nextcloud.DOMAIN.TLD/apps/dicomviewer/ncviewer/31fb9346313fc3740d7b.woff2
    Request Method      GET
    Status Code         200
    ```

- **WebGL available:** viewer renders normally (no behavior change)
- **WebGL blocked** (fingerprinting protection on): opening a DICOM now shows the message instead of a blank viewer:
  <img width="1707" height="829" alt="image" src="https://github.com/user-attachments/assets/2bebc086-4ea5-45bf-b5a9-a95385328a52" />

* * *

### AI Disclosure
*Developed with assistance from Claude Code (Opus 4.8). The LLM helped me identify the related files, code parts and proposed possible code modifications and fixes.*
*I've manually reviewed and cleaned the code the best I could.*